### PR TITLE
fixed a bug that GITLAB_CI_PORT configuration option is not worked correctly

### DIFF
--- a/assets/config/nginx/gitlab_ci
+++ b/assets/config/nginx/gitlab_ci
@@ -7,7 +7,7 @@ upstream gitlab_ci {
 }
 
 server {
-  listen 80 default_server;         # e.g., listen 192.168.1.1:80;
+  listen {{GITLAB_CI_PORT}};         # e.g., listen 192.168.1.1:80;
   server_name {{YOUR_SERVER_FQDN}};     # e.g., server_name source.example.com;
   root /home/gitlab_ci/gitlab-ci/public;
 


### PR DESCRIPTION
Hi,

I fixed a issue that Gitlab-CI is always listening at port 80 even if set GITLAB_CI_PORT.
