### PR TITLE
Added `SMTP_CA_ENABLED`, `SMTP_CA_PATH` and `SMTP_CA_FILE` configuration options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,9 @@ Below is the complete list of available options that can be used to customize yo
 - **SMTP_STARTTLS**: Enable STARTTLS. Defaults to `true`.
 - **SMTP_TLS**: Enable SSL/TLS. Defaults to `false`.
 - **SMTP_AUTHENTICATION**: Specify the SMTP authentication method. Defaults to `login` if `SMTP_USER` is set.
+- **SMTP_CA_ENABLED**: Enable custom CA certificates for SMTP email configuration. Defaults to `false`.
+- **SMTP_CA_PATH**: Specify the `ca_path` parameter for SMTP email configuration. Defaults to `/home/gitlab_ci/data/certs`.
+- **SMTP_CA_FILE**: Specify the `ca_file` parameter for SMTP email configuration. Defaults to `/home/gitlab_ci/data/certs/ca.crt`.
 - **AWS_BACKUPS**: Enables automatic uploads to an Amazon S3 instance. Defaults to `false`.
 - **AWS_BACKUP_REGION**: AWS region. No defaults.
 - **AWS_BACKUP_ACCESS_KEY_ID**: AWS access key id. No defaults.

--- a/assets/config/gitlab-ci/smtp_settings.rb
+++ b/assets/config/gitlab-ci/smtp_settings.rb
@@ -17,6 +17,8 @@ if Rails.env.production?
     authentication: "{{SMTP_AUTHENTICATION}}",
     openssl_verify_mode: "{{SMTP_OPENSSL_VERIFY_MODE}}",
     enable_starttls_auto: {{SMTP_STARTTLS}},
+    ca_path: "{{SMTP_CA_PATH}}",
+    ca_file: "{{SMTP_CA_FILE}}",
     tls: {{SMTP_TLS}}
   }
 end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,6 +61,9 @@ SMTP_PASS=${SMTP_PASS:-}
 SMTP_OPENSSL_VERIFY_MODE=${SMTP_OPENSSL_VERIFY_MODE:-}
 SMTP_STARTTLS=${SMTP_STARTTLS:-true}
 SMTP_TLS=${SMTP_TLS:-false}
+SMTP_CA_ENABLED=${SMTP_CA_ENABLED:-false}
+SMTP_CA_PATH=${SMTP_CA_PATH:-$GITLAB_CI_DATA_DIR/certs}
+SMTP_CA_FILE=${SMTP_CA_FILE:-$GITLAB_CI_DATA_DIR/certs/ca.crt}
 if [[ -n ${SMTP_USER} ]]; then
   SMTP_ENABLED=${SMTP_ENABLED:-true}
   SMTP_AUTHENTICATION=${SMTP_AUTHENTICATION:-login}
@@ -394,6 +397,19 @@ if [[ ${SMTP_ENABLED} == true ]]; then
     "") sudo -HEu ${GITLAB_CI_USER} sed '/{{SMTP_AUTHENTICATION}}/d' -i config/initializers/smtp_settings.rb ;;
     *) sudo -HEu ${GITLAB_CI_USER} sed 's/{{SMTP_AUTHENTICATION}}/'"${SMTP_AUTHENTICATION}"'/' -i config/initializers/smtp_settings.rb ;;
   esac
+
+  if [[ ${SMTP_CA_ENABLED} == true ]]; then
+    if [[ -d ${SMTP_CA_PATH} ]]; then
+      sudo -HEu ${GITLAB_CI_USER} sed 's,{{SMTP_CA_PATH}},'"${SMTP_CA_PATH}"',' -i config/initializers/smtp_settings.rb
+    fi
+
+    if [[ -f ${SMTP_CA_FILE} ]]; then
+      sudo -HEu ${GITLAB_CI_USER} sed 's,{{SMTP_CA_FILE}},'"${SMTP_CA_FILE}"',' -i config/initializers/smtp_settings.rb
+    fi
+  else
+    sudo -HEu ${GITLAB_CI_USER} sed '/{{SMTP_CA_PATH}}/d' -i config/initializers/smtp_settings.rb
+    sudo -HEu ${GITLAB_CI_USER} sed '/{{SMTP_CA_FILE}}/d' -i config/initializers/smtp_settings.rb
+  fi
 fi
 
 # take ownership of ${GITLAB_CI_DATA_DIR}


### PR DESCRIPTION
Without ca_path or ca_file, custom CA certs are not taken into account during the
SMTP SSL/TLS handshake. Since the SMTP email configuration allows the use of CApath
and CAfile for OpenSSL, it should be allowed to set these parameters.

See also:
https://gitlab.com/gitlab-org/omnibus-gitlab/commit/fa9c1464bc1eb173660edfded1a2f7add7ac24b3

Signed-off-by: Scott Fan fancp2007@gmail.com
